### PR TITLE
Add SSH Keys when provisioning VPS and minor fix

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -12,16 +12,17 @@ Manages SiteHost Server Instance. Make sure to checkout our [developer KB articl
 - [Return](#return-values)
 
 ## Parameters
-| Field     | Type | Required | Description                                                                  |
-|-----------|------|----------|------------------------------------------------------------------------------|
-| `state` | <center>`str`</center> | <center>Optional **(Default: present)**</center> | The desired state of the target.  **(Choices: `present`, `absent`, `started`,`stopped`, `restarted`)** |
-| `label` | <center>`str`</center> | <center>Optional</center> | User chosen label of the new server, **mutually exclusive to `name`**.  Please ensure that verbose mode `-v` is enabled to see the password of the newly created server.  |
-| `name` | <center>`str`</center> | <center>Optional</center> | Unique auto generated machine name for server. Used to select servers that are **already present**. |
-| `location` | <center>`str`</center> | <center>Optional</center> | The code for the [location](https://kb.sitehost.nz/developers/api/locations) to provision the new server at. *eg. AKLCITY* |
-| `product_code` | <center>`str`</center> | <center>Optional</center> | The code for the [server specification](specification,https://kb.sitehost.nz/developers/api/product-codes) to use when provisioning the new server. *eg. XENLIT*|
-| `image` | <center>`str`</center> | <center>Optional</center> | The [image](https://kb.sitehost.nz/developers/api/images) to use for the new server. *eg. ubuntu-jammy-pvh.amd64*   |
-| `api_key` | <center>`str`</center> | <center>**Required**</center> | Your SiteHost API key [generated from CP](https://kb.sitehost.nz/developers/api#creating-an-api-key). |
-| `api_client_id` | <center>`int`</center> | <center>**Required**</center> | The client ID of your SiteHost account. |
+| Field           | Type                        | Required                                         | Description                                                                                                                                                              |
+|-----------------|-----------------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `state`         | <center>`str`</center>      | <center>Optional **(Default: present)**</center> | The desired state of the target.  **(Choices: `present`, `absent`, `started`,`stopped`, `restarted`)**                                                                   |
+| `label`         | <center>`str`</center>      | <center>Optional</center>                        | User chosen label of the new server, **mutually exclusive to `name`**.  Please ensure that verbose mode `-v` is enabled to see the password of the newly created server. |
+| `name`          | <center>`str`</center>      | <center>Optional</center>                        | Unique auto generated machine name for server. Used to select servers that has **already present**.                                                                      |
+| `location`      | <center>`str`</center>      | <center>Optional</center>                        | The code for the [location](https://kb.sitehost.nz/developers/api/locations) to provision the new server at. *eg. AKLCITY*                                               |
+| `product_code`  | <center>`str`</center>      | <center>Optional</center>                        | The code for the [server specification](specification,https://kb.sitehost.nz/developers/api/product-codes) to use when provisioning the new server. *eg. XENLIT*         |
+| `image`         | <center>`str`</center>      | <center>Optional</center>                        | The [image](https://kb.sitehost.nz/developers/api/images) to use for the new server. *eg. ubuntu-jammy-pvh.amd64*                                                        |
+| `ssh_keys`      | <center>`str list`</center> | <center>Optional</center>                        | The client ssh public keys *eg. 'ssh-rsa AAAAB3NzaC1yc2EAAA... user@host*                                                                                                                                              |
+| `api_key`       | <center>`str`</center>      | <center>**Required**</center>                    | Your SiteHost API key [generated from CP](https://kb.sitehost.nz/developers/api#creating-an-api-key).                                                                    |
+| `api_client_id` | <center>`int`</center>      | <center>**Required**</center>                    | The client id of your SiteHost account.                                                                                                                                  |
 
 
 ### Restrictions
@@ -41,7 +42,7 @@ For example, use `product_code: CLDCON1` for a 1 core Cloud Container Server.
 
 ## Examples
 
-- Creating a VPS, use `-v` as argument when running the playbook to see password:
+- Creating a VPS, `ssh_keys` is optional, use `-v` as argument when running the playbook to see password:
 ```yml
 - name: create a 1 core VPS with ubuntu jammy image
   sitehost.cloud.server:
@@ -49,12 +50,13 @@ For example, use `product_code: CLDCON1` for a 1 core Cloud Container Server.
     location: AKLCITY
     product_code: XENLIT
     image: ubuntu-jammy-pvh.amd64
+    ssh_keys: "{{ SSH_PUBLIC_KEY }}"
     api_client_id: "{{ CLIENT_ID }}"
     api_key: "{{ USER_API_KEY }}"
     state: present
 ```
 
-- Create a VPS and register its output to shserver and outputs the password with debug:
+- Create a VPS (`ssh_keys` is optional) and register its output to shserver and outputs the password with debug:
 ```yml
 - name: create a 1 core VPS with ubuntu jammy image
   sitehost.cloud.server:
@@ -62,6 +64,7 @@ For example, use `product_code: CLDCON1` for a 1 core Cloud Container Server.
     location: AKLCITY
     product_code: XENLIT
     image: ubuntu-jammy-pvh.amd64
+    ssh_keys: "{{ SSH_PUBLIC_KEY }}"
     api_client_id: "{{ CLIENT_ID }}"
     api_key: "{{ USER_API_KEY }}"
     state: present
@@ -72,7 +75,7 @@ For example, use `product_code: CLDCON1` for a 1 core Cloud Container Server.
     msg: "{{ shserver.server.password }}"
 ```
 
-- Creating a server then upgrading it.
+- Creating a server (`ssh_keys` is optional) then upgrading it.
 ```yml
 - name: create a 1 core VPS with ubuntu jammy image
   sitehost.cloud.server:
@@ -80,13 +83,14 @@ For example, use `product_code: CLDCON1` for a 1 core Cloud Container Server.
     location: AKLCITY
     product_code: XENLIT
     image: ubuntu-jammy-pvh.amd64
+    ssh_keys: "{{ SSH_PUBLIC_KEY }}"
     api_client_id: "{{ CLIENT_ID }}"
     api_key: "{{ USER_API_KEY }}"
     state: present
   register: shserver 
 
 - name: upgrade the previously created server
-    sitehost.cloud.server:
+  sitehost.cloud.server:
     name: "{{ shserver.server.name }}"
     product_code: XENPRO
     api_client_id: "{{ CLIENT_ID }}"
@@ -135,6 +139,10 @@ For example, use `product_code: CLDCON1` for a 1 core Cloud Container Server.
             - returned: On success, and only returned during server creation.
             - type: str
             - sample: `Up8Da5oE60ns`
+        - `ips` - IP addresses of the user
+            - returned: On success, and only returned during server creation.
+            - type: str
+            - sample: `192.168.7.46`
         - `state` - The state of the server after executing the command.
             - returned: On sucess
             - type: str

--- a/plugins/module_utils/sitehost.py
+++ b/plugins/module_utils/sitehost.py
@@ -55,7 +55,7 @@ class SitehostAPI:
         skip_status_check=False,
     ):
         """
-        low level function that directly make http rquest to the sitehost api
+        low level function that directly make http request to the SiteHost api
 
             Parameters:
                 path (str): should point to the api resource such as "/server/provision.json"
@@ -95,7 +95,7 @@ class SitehostAPI:
         if r.status_code == HTTP_INTERNAL_SERVER_ERROR_STATUS_CODE:
             self.module.fail_json(
                 msg=(
-                    "An unexpected error has occured while calling SiteHost API,"
+                    "An unexpected error has occurred while calling SiteHost API,"
                     "please contact SiteHost support."
                 ),
                 path=path,
@@ -151,7 +151,7 @@ class SitehostAPI:
 
             job_status = job_resource.get("return")["state"]
 
-            # return information on job details when it succeded
+            # return information on job details when it succeeded
             if job_status == state:
                 return job_resource["return"]
             elif job_status == "Failed":
@@ -169,10 +169,10 @@ class SitehostAPI:
     @staticmethod
     def _backoff(retry, retry_max_delay=60):
         """
-        Pause the computation for some time, based on the number of retries
-        retries are kept track by the parent wait_for_job() method.
+        Pause the computation for some time, based on the number of retries.
+        Retries are kept track by the parent wait_for_job() method.
 
-        Basically with every iteration of retry, the function will wait alittle longer
+        Basically with every iteration of retry, the function will wait a little longer
         until it waits for a max of retry_max_delay seconds.
 
         :param retry: The current iteration of the delay method


### PR DESCRIPTION
## Motivation

- SiteHost VPS can be provisioned with SSH key from Control Panel. However, this feature has not been integrated with Ansible. Currently, when users create a VPS via Ansible, they need to keep track the password to access the server. Having the SSH keys when provisioning a server would make it more convenient for users.

- Currently, our returned message when successfully creating a VPS has a bug. 
   - We set the `self.result["server"]["password"] = api_result["return"]["password"]` first and then assign new dict for `server`at the end `self.result["server"]= self._get_server_by_name(api_result["return"]["name"])`. With this implementation, new `server` dict would be overwrite again that make all attributes set to the server before are lost.  
   - In this case we should:
      + set up `server` dict first before adding any sub attributes such as `password`.
      + create a new attribute, e.g `server.info` containing server info.

-  The best practice is checking the attributes in `return` message first before getting it to avoid unexpected panic. We should not assume that the response contains what we want because it is from different repo. 
   - For example: when provisioning a server in staging env, as the space is not enough, no `return` dict in the response. This leads to the error in Ansible and make users hard to debug.
   
 - Some misspelling should be fixed.
 
## Summary of changes:
- add ssh keys in ansible script when creating server.
- fix return `server` when provisioning a VPS.
- check returned message for APIs before getting attributes to avoid errors.
- fix misspellings
- add ssh_keys information and instructions